### PR TITLE
fix: typos in Astroturf rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -378,8 +378,8 @@ function createAtoms(options?: WebpackAtomsOptions): WebpackAtoms {
       use: [loaders.astroturf(options)],
     })
 
-    astroturf.sass = opts => astroturf({ extension: 'module.scss', ...opts })
-    astroturf.less = opts => astroturf({ extension: 'module.scss', ...opts })
+    astroturf.sass = opts => astroturf({ extension: '.module.scss', ...opts })
+    astroturf.less = opts => astroturf({ extension: '.module.less', ...opts })
 
     rules.astroturf = astroturf
   }


### PR DESCRIPTION
Fixes a typo in Astroturf `less`, and prevents module exports from missing a preceding period (ie. `myComponentmodules.scss` as opposed to the correct `myComponent.modules.scss`)

Also potentially a "breaking change" in case people coded to the incorrect naming.