### PR TITLE
fix: relax "Env" type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import type { FaviconWebpackPlugionOptions } from 'favicons-webpack-plugin/src/o
 
 export type { FaviconWebpackPlugionOptions, HtmlWebpackPlugin }
 
-export type Env = 'production' | 'test' | 'development'
+export type Env = string
 
 export type LoaderResolver<T extends {}> = (options?: T) => RuleSetUseItem
 


### PR DESCRIPTION
Is the current string literal type too restrictive or was that intentional?